### PR TITLE
47 smrf_ipysnobal output SMRF variables

### DIFF
--- a/awsm/models/pysnobal/ipysnobal.py
+++ b/awsm/models/pysnobal/ipysnobal.py
@@ -450,13 +450,9 @@ class PySnobal():
 
         with SMRF(self.awsm.smrf_connector.smrf_config, self._logger) as self.smrf:
 
-            # load topo data
             self.smrf.loadTopo()
-
-            # 3. initialize the distribution
             self.smrf.create_distribution()
-
-            # load weather data  and station metadata
+            self.smrf.initializeOutput()
             self.smrf.loadData()
 
             # run threaded or not
@@ -488,7 +484,7 @@ class PySnobal():
             startTime = datetime.now()
 
             self.smrf.distribute_single_timestep(self.time_step)
-            # perhaps put s.output() here to get SMRF output?
+            self.smrf.output(self.time_step)
 
             self.smrf_ipysnobal_time_step()
 
@@ -511,17 +507,27 @@ class PySnobal():
         self.variable_list = self.smrf.create_output_variable_dict(
             self.FORCING_VARIABLES, '.')
 
+        self.initialize_updater()
+
         self.smrf.create_data_queue()
         self.smrf.set_queue_variables()
         self.smrf.create_distributed_threads()
+
+        # output thread
+        self.smrf.threads.append(
+            queue.QueueOutput(
+                self.smrf.smrf_queue,
+                self.date_time,
+                self.smrf.out_func,
+                self.smrf.config['output']['frequency'],
+                self.smrf.topo.nx,
+                self.smrf.topo.ny))
+
+        # ipysnobal queue and thread
         self.smrf.smrf_queue['ipysnobal'] = queue.DateQueueThreading(
             self.smrf.queue_max_values,
             self.smrf.time_out,
             name='ipysnobal')
-
-        del self.smrf.smrf_queue['output']
-
-        self.initialize_updater()
 
         self.smrf.threads.append(
             threading.Thread(

--- a/awsm/models/smrf_connector.py
+++ b/awsm/models/smrf_connector.py
@@ -56,10 +56,6 @@ class SMRFConnector():
         smrf_config.cfg['time']['start_date'] = self.myawsm.start_date
         smrf_config.cfg['time']['end_date'] = self.myawsm.end_date
 
-        # change start date if using smrf_ipysnobal and restarting
-        if self.myawsm.restart_run and self.myawsm.run_smrf_ipysnobal:
-            smrf_config.cfg['time']['start_date'] = self.myawsm.restart_date
-
         # set output location in smrf config
         smrf_config.cfg['output']['out_location'] = self.myawsm.path_output
         self.output_path = self.myawsm.path_output
@@ -90,6 +86,7 @@ class SMRFConnector():
                 self.force[variable] = nc.Dataset(
                     os.path.join(self.output_path, '{}.nc'.format(variable)),
                     'r')
+                self.force[variable].set_always_mask(False)
 
             except FileNotFoundError:
                 self.force['soil_temp'] = float(self.myawsm.soil_temp) * \

--- a/awsm/tests/basins/RME/config.ini
+++ b/awsm/tests/basins/RME/config.ini
@@ -225,7 +225,6 @@ queue_max_values:              1.0
 [awsm master]
 run_smrf:                      True
 model_type:                    ipysnobal
-mask_isnobal:                  False
 
 
 ################################################################################
@@ -250,7 +249,6 @@ log_to_file:                   True
 run_for_nsteps:                None
 output_frequency:              1
 daily_folders:                 False
-variables:                     thickness, snow_density, specific_mass, liquid_water, temperature_surface, temperature_lower, temperature_snowcover, thickness_lower, water_saturation, net_radiation, sensible_heat, latent_heat, snow_soil, precip_advected, sum_energy_balance, evaporation, snowmelt, surface_water_input, cold_content
 
 
 ################################################################################
@@ -278,3 +276,5 @@ thresh_small:                  1
 z_u:                           5.0
 z_t:                           5.0
 z_g:                           0.5
+mask_isnobal:                  False
+variables:                     thickness, snow_density, specific_mass, liquid_water, temperature_surface, temperature_lower, temperature_snowcover, thickness_lower, water_saturation, net_radiation, sensible_heat, latent_heat, snow_soil, precip_advected, sum_energy_balance, evaporation, snowmelt, surface_water_input, cold_content

--- a/awsm/tests/output/test_file_output.py
+++ b/awsm/tests/output/test_file_output.py
@@ -1,0 +1,90 @@
+from glob import glob
+
+from inicheck.tools import cast_all_variables
+
+from awsm.framework.framework import run_awsm
+from awsm.tests.awsm_test_case import AWSMTestCase
+
+
+class TestOutput(AWSMTestCase):
+    """
+    Testing using RME:
+        - ipysnobal
+        - initialize with all zeros
+        - loading from netcdf
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.gold_dir = cls.basin_dir.joinpath('gold')
+        cls.output_path = cls.basin_dir.joinpath(
+            'output/rme/wy1986/rme_test/run19860217_19860217'
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.create_output_dir()
+
+    def tearDown(self):
+        super().tearDown()
+        self.remove_output_dir()
+
+    def assert_file_number(self, number):
+        files = glob(str(self.output_path.joinpath('*.nc')))
+        self.assertTrue(len(files) == number)
+
+    def test_output_11_files(self):
+        run_awsm(self.run_config)
+        self.assert_file_number(11)
+
+    def test_ouput_smrf_ipysnobal_11_files(self):
+        config = self.base_config_copy()
+        config.raw_cfg['awsm master']['run_smrf'] = False
+        config.raw_cfg['awsm master']['model_type'] = 'smrf_ipysnobal'
+        config.raw_cfg['system']['threading'] = False
+
+        config.apply_recipes()
+        config = cast_all_variables(config, config.mcfg)
+
+        run_awsm(config)
+        self.assert_file_number(11)
+
+    def test_ouput_smrf_ipysnobal_2_files(self):
+        config = self.base_config_copy()
+        config.raw_cfg['output']['variables'] = 'air_temp'
+        config.raw_cfg['awsm master']['run_smrf'] = False
+        config.raw_cfg['awsm master']['model_type'] = 'smrf_ipysnobal'
+        config.raw_cfg['system']['threading'] = False
+
+        config.apply_recipes()
+        config = cast_all_variables(config, config.mcfg)
+
+        run_awsm(config)
+        self.assert_file_number(2)
+
+    def test_ouput_smrf_ipysnobal_threaded_11_files(self):
+        config = self.base_config_copy()
+        config.raw_cfg['awsm master']['run_smrf'] = False
+        config.raw_cfg['awsm master']['model_type'] = 'smrf_ipysnobal'
+        config.raw_cfg['system']['threading'] = True
+
+        config.apply_recipes()
+        config = cast_all_variables(config, config.mcfg)
+
+        run_awsm(config)
+        self.assert_file_number(11)
+
+    def test_ouput_smrf_ipysnobal_threaded_3_files(self):
+        config = self.base_config_copy()
+        config.raw_cfg['output']['variables'] = ['air_temp', 'vapor_pressure']
+        config.raw_cfg['awsm master']['run_smrf'] = False
+        config.raw_cfg['awsm master']['model_type'] = 'smrf_ipysnobal'
+        config.raw_cfg['system']['threading'] = True
+
+        config.apply_recipes()
+        config = cast_all_variables(config, config.mcfg)
+
+        run_awsm(config)
+        self.assert_file_number(3)

--- a/awsm/tests/output/test_file_output.py
+++ b/awsm/tests/output/test_file_output.py
@@ -88,3 +88,29 @@ class TestOutput(AWSMTestCase):
 
         run_awsm(config)
         self.assert_file_number(3)
+
+    def test_ouput_smrf_ipysnobal_1_file(self):
+        config = self.base_config_copy()
+        config.raw_cfg['output']['variables'] = []
+        config.raw_cfg['awsm master']['run_smrf'] = False
+        config.raw_cfg['awsm master']['model_type'] = 'smrf_ipysnobal'
+        config.raw_cfg['system']['threading'] = False
+
+        config.apply_recipes()
+        config = cast_all_variables(config, config.mcfg)
+
+        run_awsm(config)
+        self.assert_file_number(1)
+
+    def test_ouput_smrf_ipysnobal_threaded_1_file(self):
+        config = self.base_config_copy()
+        config.raw_cfg['output']['variables'] = []
+        config.raw_cfg['awsm master']['run_smrf'] = False
+        config.raw_cfg['awsm master']['model_type'] = 'smrf_ipysnobal'
+        config.raw_cfg['system']['threading'] = True
+
+        config.apply_recipes()
+        config = cast_all_variables(config, config.mcfg)
+
+        run_awsm(config)
+        self.assert_file_number(1)


### PR DESCRIPTION
Now has the ability to output the SMRF variables with the model type `smrf_ipysnobal` in both serial and threaded mode.

This is required for restarting ipysnobal and part of #71 